### PR TITLE
Support for Certhash codec

### DIFF
--- a/Sources/Multiaddr/Address.swift
+++ b/Sources/Multiaddr/Address.swift
@@ -37,6 +37,20 @@ public struct Address: Equatable {
         let bytes = [addrProtocol.packedCode(), try binaryPackedAddress()].compactMap{$0}.flatMap{$0}
         return Data(bytes: bytes, count: bytes.count)
     }
+    
+    public static func == (lhs: Address, rhs: Address) -> Bool {
+        switch (lhs.addrProtocol, rhs.addrProtocol) {
+        case (.certhash, .certhash):
+            do {
+                guard let leftAddress = lhs.address, let rightAddress = rhs.address else { return false }
+                return try Multihash(multihash: leftAddress).value == Multihash(multihash: rightAddress).value
+            } catch {
+                return false
+            }
+        default:
+            return lhs.addrProtocol == rhs.addrProtocol && lhs.address == rhs.address
+        }
+    }
 }
 
 extension Address {

--- a/Sources/Multiaddr/Multiaddr.swift
+++ b/Sources/Multiaddr/Multiaddr.swift
@@ -124,7 +124,7 @@ public struct Multiaddr: Equatable {
         /// If we found a match, replace it's Address
         if let idx = matchIndex {
             var newAddresses = self.addresses
-            newAddresses[idx] = Address(addrProtocol: codec, address: newAddress)
+            newAddresses[idx] = try Address(addrProtocol: codec, address: newAddress)
             let newMA = Multiaddr(newAddresses)
             try newMA.validate()
             return newMA
@@ -143,7 +143,7 @@ public struct Multiaddr: Equatable {
         
         /// If we found a match, replace it's Address
         if let idx = matchIndex {
-            self.addresses[idx] = Address(addrProtocol: codec, address: newAddress)
+            self.addresses[idx] = try Address(addrProtocol: codec, address: newAddress)
         } else {
             throw MultiaddrError.unknownCodec
         }
@@ -180,7 +180,7 @@ extension Multiaddr {
                 components.removeFirst()
                 addressElements.append(next)
             }
-            let newAddress = Address(addrProtocol: try MultiaddrProtocol(current), address: addressElements.combined())
+            let newAddress = try Address(addrProtocol: MultiaddrProtocol(current), address: addressElements.combined())
             addresses.append(newAddress)
         }
         return addresses
@@ -199,7 +199,7 @@ extension Multiaddr {
             guard let proto = try? MultiaddrProtocol(decodedVarint.value) else { throw MultiaddrError.unknownProtocol }
 
             if case .zero = proto.size() {
-                addresses.append(Address(addrProtocol: proto))
+                addresses.append(try Address(addrProtocol: proto))
                 continue
             }
             
@@ -207,7 +207,7 @@ extension Multiaddr {
             let addressBytes = Data(buffer.prefix(addressSize))
             let address = Address(addrProtocol: proto, addressData: addressBytes)
             addresses.append(address)
-            
+                    
             buffer.removeFirst(addressSize)
         }
         
@@ -222,7 +222,8 @@ extension Multiaddr {
 
 extension Multiaddr: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.description)
+        //hasher.combine(self.description)
+        hasher.combine(try! self.binaryPacked())
     }
 }
 

--- a/Sources/Multiaddr/Protocol.swift
+++ b/Sources/Multiaddr/Protocol.swift
@@ -19,11 +19,10 @@ enum BitSize {
 extension MultiaddrProtocol {
     func isMultiaddrProtocol() -> Bool {
         switch self {
-        case .ip4, .tcp, .udp, .dccp, .ip6, .ip6zone, .dns4, .dns6, .dnsaddr, .sctp, .udt, .utp, .unix, .p2p, .ipfs, .http,
-             .https, .onion, .onion3, .garlic64, .garlic32, .quic, .ws, .wss, .p2p_websocket_star, .p2p_webrtc_star, .p2p_webrtc_direct, .p2p_circuit:
+        case .ip4, .tcp, .dns, .dns4, .dns6, .dnsaddr, .udp, .dccp, .ip6, .ip6zone, .ipcidr, .quic, .quic_v1, .webtransport, .certhash, .sctp, .p2p_circuit, .udt, .utp, .unix, .p2p, .ipfs, .http, .https, .onion, .onion3, .garlic64, .garlic32, .p2p_webrtc_direct, .tls, .sni, .noise, .ws, .wss, .plaintextv2, .webrtc_direct, .webrtc:
             return true
-        //case .p2pWebsocketStar, .p2pWebrtcStar, .p2pWebrtcDirect, .p2pCircuit, .memory:
-        //    return true
+        case .p2p_websocket_star, .p2p_webrtc_star: //, .p2pWebrtcDirect, .p2pCircuit, .memory:
+            return true
         default:
             return false
         }
@@ -43,6 +42,8 @@ extension MultiaddrProtocol {
         case .onion3:
             return .fixed(bits: 296)
         case .ipfs, .dns4, .dns6, .unix, .p2p:
+            return .variable
+        case .certhash:
             return .variable
         default:
             return .zero

--- a/Tests/MultiaddrTests/ProtocolTests.swift
+++ b/Tests/MultiaddrTests/ProtocolTests.swift
@@ -719,7 +719,7 @@ class ProtocolsTests: XCTestCase {
         print(addr)
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
-        XCTAssertEqual(addr.addresses, [Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
     }
     
 //      it('p2p', () => {
@@ -735,7 +735,7 @@ class ProtocolsTests: XCTestCase {
         print(addr) //p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t
         // Description should equal initialization string
         XCTAssertEqual(addr.description, "/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
-        XCTAssertEqual(addr.addresses, [Address(addrProtocol: .p2p, address: "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")])
     }
     
 //      it('ipfs', () => {
@@ -751,8 +751,8 @@ class ProtocolsTests: XCTestCase {
         let addr = try Multiaddr(str)
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
-        XCTAssertEqual(addr.addresses, [Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
-        XCTAssertNotEqual(addr.addresses, [Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
+        XCTAssertNotEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
     }
     
 //      it('onion', () => {
@@ -766,7 +766,7 @@ class ProtocolsTests: XCTestCase {
         let addr = try Multiaddr(str)
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
-        XCTAssertEqual(addr.addresses, [Address(addrProtocol: .onion, address: "timaq4ygg2iegci7:1234")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .onion, address: "timaq4ygg2iegci7:1234")])
     }
     
 //      it('onion bad length', () => {
@@ -811,7 +811,7 @@ class ProtocolsTests: XCTestCase {
         let addr = try Multiaddr(str)
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
-        XCTAssertEqual(addr.addresses, [Address(addrProtocol: .onion3, address: "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .onion3, address: "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234")])
     }
     
 //      it('onion3 bad length', () => {
@@ -854,8 +854,8 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-                        Address(addrProtocol: .p2p_circuit, address: nil),
-                        Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+            try Address(addrProtocol: .p2p_circuit, address: nil),
+            try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
         ])
     }
     
@@ -871,8 +871,8 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-                        Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"),
-                        Address(addrProtocol: .p2p_circuit, address: "")
+            try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"),
+            try Address(addrProtocol: .p2p_circuit, address: "")
         ])
     }
     
@@ -888,8 +888,8 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"),
-            Address(addrProtocol: .p2p_circuit, address: "")
+            try Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"),
+            try Address(addrProtocol: .p2p_circuit, address: "")
         ])
     }
     
@@ -905,11 +905,11 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ip4, address: "127.0.0.1"),
-            Address(addrProtocol: .tcp, address: "9090"),
-            Address(addrProtocol: .ws, address: ""),
-            Address(addrProtocol: .p2p_webrtc_star, address: ""),
-            Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+            try Address(addrProtocol: .ip4, address: "127.0.0.1"),
+            try Address(addrProtocol: .tcp, address: "9090"),
+            try Address(addrProtocol: .ws, address: ""),
+            try Address(addrProtocol: .p2p_webrtc_star, address: ""),
+            try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
         ])
     }
     
@@ -925,11 +925,11 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ip4, address: "127.0.0.1"),
-            Address(addrProtocol: .tcp, address: "9090"),
-            Address(addrProtocol: .ws, address: ""),
-            Address(addrProtocol: .p2p_webrtc_star, address: ""),
-            Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+            try Address(addrProtocol: .ip4, address: "127.0.0.1"),
+            try Address(addrProtocol: .tcp, address: "9090"),
+            try Address(addrProtocol: .ws, address: ""),
+            try Address(addrProtocol: .p2p_webrtc_star, address: ""),
+            try Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
         ])
     }
     
@@ -939,11 +939,11 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, "/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ip4, address: "127.0.0.1"),
-            Address(addrProtocol: .tcp, address: "9090"),
-            Address(addrProtocol: .ws, address: ""),
-            Address(addrProtocol: .p2p_webrtc_star, address: ""),
-            Address(addrProtocol: .ipfs, address: "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
+            try Address(addrProtocol: .ip4, address: "127.0.0.1"),
+            try Address(addrProtocol: .tcp, address: "9090"),
+            try Address(addrProtocol: .ws, address: ""),
+            try Address(addrProtocol: .p2p_webrtc_star, address: ""),
+            try Address(addrProtocol: .ipfs, address: "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
         ])
     }
 //      it('p2p-webrtc-direct', () => {
@@ -958,10 +958,10 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ip4, address: "127.0.0.1"),
-            Address(addrProtocol: .tcp, address: "9090"),
-            Address(addrProtocol: .http, address: ""),
-            Address(addrProtocol: .p2p_webrtc_direct, address: "")
+            try Address(addrProtocol: .ip4, address: "127.0.0.1"),
+            try Address(addrProtocol: .tcp, address: "9090"),
+            try Address(addrProtocol: .http, address: ""),
+            try Address(addrProtocol: .p2p_webrtc_direct, address: "")
         ])
     }
     
@@ -977,10 +977,10 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [
-            Address(addrProtocol: .ip4, address: "127.0.0.1"),
-            Address(addrProtocol: .tcp, address: "9090"),
-            Address(addrProtocol: .ws, address: ""),
-            Address(addrProtocol: .p2p_websocket_star, address: "")
+            try Address(addrProtocol: .ip4, address: "127.0.0.1"),
+            try Address(addrProtocol: .tcp, address: "9090"),
+            try Address(addrProtocol: .ws, address: ""),
+            try Address(addrProtocol: .p2p_websocket_star, address: "")
         ])
     }
     


### PR DESCRIPTION
This PR introduces support for...
- `certhash` within `multiaddr`'s. 
- A more comprehensive `equatable` implementation
- Hashes on `binaryPacked()` value instead of `description`
- Validates `p2p`/`ipfs` `CID`s and `certhash` `Multihash` upon `Address` creation 