### PR TITLE
Additional Protocol Support and Tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
         .package(url: "https://github.com/swift-libp2p/swift-multibase.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/swift-libp2p/swift-multihash.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/swift-libp2p/swift-cid.git", .upToNextMajor(from: "0.0.1"))
-        //.package(name: "PeerID", path: "../PeerID")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Multiaddr/Address.swift
+++ b/Sources/Multiaddr/Address.swift
@@ -13,12 +13,12 @@ import CID
 
 public struct Address: Equatable {
     let addrProtocol: MultiaddrProtocol
-    var address: String?
+    let address: String?
     
     init(addrProtocol: MultiaddrProtocol, addressData: Data) {
         self.addrProtocol = addrProtocol
         guard !addressData.isEmpty else { self.address = nil; return }
-        self.address = try? unpackAddress(addressData)
+        self.address = try? Address.unpackAddress(addressData, for: addrProtocol)
     }
     
     init(addrProtocol: MultiaddrProtocol, address: String? = nil) throws {
@@ -27,7 +27,7 @@ public struct Address: Equatable {
         case .p2p, .ipfs:
             //Ensure addy is a valid CID or Multihash compliant String and store it as a b58 String if so...
             guard let address = address, !address.isEmpty else { throw MultiaddrError.parseAddressFail }
-            guard let address = (try? CID(address).multihash.b58String) ?? (try? Multihash(multihash: address).b58String) else { throw MultiaddrError.parseAddressFail }
+            guard ((try? CID(address)) != nil) || ((try? Multihash(multihash: address)) != nil) else { throw MultiaddrError.parseAddressFail }
             self.address = address
         case .certhash:
             // Ensure Certhash is a valid Multihash
@@ -35,17 +35,19 @@ public struct Address: Equatable {
             guard (try? Multihash(multihash: address)) != nil else { throw MultiaddrError.parseAddressFail }
             self.address = address
         default:
-            if let address = address {
+            if var address = address {
+                if address.hasSuffix("/") { address.removeLast() }
                 if address.isEmpty { self.address = nil }
                 else { self.address = address }
             } else {
                 self.address = nil
             }
         }
+        let _ = try Address.binaryPackedAddress(self.address, for: self.addrProtocol)
     }
     
     func binaryPacked() throws -> Data {
-        let bytes = [addrProtocol.packedCode(), try binaryPackedAddress()].compactMap{$0}.flatMap{$0}
+        let bytes = [addrProtocol.packedCode(), try Address.binaryPackedAddress(self.address, for: self.addrProtocol)].compactMap{$0}.flatMap{$0}
         return Data(bytes: bytes, count: bytes.count)
     }
     
@@ -58,6 +60,13 @@ public struct Address: Equatable {
             } catch {
                 return false
             }
+        case (.p2p, .p2p), (.ipfs, .ipfs), (.p2p, .ipfs), (.ipfs, .p2p):
+            do {
+                guard let leftAddress = lhs.address, let rightAddress = rhs.address else { return false }
+                return try CID(leftAddress).multihash == CID(rightAddress).multihash
+            } catch {
+                return false
+            }
         default:
             return lhs.addrProtocol == rhs.addrProtocol && lhs.address == rhs.address
         }
@@ -66,25 +75,51 @@ public struct Address: Equatable {
 
 extension Address {
     
-    private func unpackAddress(_ addressData: Data) throws -> String? {
+    static private func unpackAddress(_ addressData: Data, for addrProtocol:MultiaddrProtocol) throws -> String? {
         switch addrProtocol {
+        case .tcp, .udp, .dccp, .sctp:
+            guard addressData.count == 2 else { throw MultiaddrError.parseAddressFail }
+            return String(addressData.uint16.bigEndian)
         case .ip4:
             return try IPv4.string(for: addressData)
         case .ip6:
             return try IPv6.string(for: addressData)
-        case .tcp, .udp, .dccp, .sctp:
-            guard addressData.count == 2 else { throw MultiaddrError.parseAddressFail }
-            return String(addressData.uint16.bigEndian)
+        case .ip6zone:
+            guard !addressData.isEmpty else { throw MultiaddrError.parseAddressFail }
+            let varInt = VarInt.uVarInt(addressData.bytes)
+            guard Int(varInt.value) + varInt.bytesRead == addressData.count else { throw MultiaddrError.parseAddressFail }
+            guard let address = String(data: Data(addressData.dropFirst(varInt.bytesRead)), encoding: .utf8) else { throw MultiaddrError.invalidFormat }
+            guard address.count > 0, !address.contains("/") else { throw MultiaddrError.invalidFormat }
+            return address
+        case .ipcidr:
+            guard addressData.count == 1 else { throw MultiaddrError.parseAddressFail }
+            let ipMask = addressData.asString(base: .base10)
+            return ipMask
         case .onion:
             return try Onion.string(for: addressData)
         case .onion3:
             return try Onion3.string(for: addressData)
+        case .garlic32:
+            guard !addressData.isEmpty else { throw MultiaddrError.parseAddressFail }
+            let varInt = VarInt.uVarInt(addressData.bytes)
+            guard Int(varInt.value) + varInt.bytesRead == addressData.count else { throw MultiaddrError.parseAddressFail }
+            return try Garlic32.string(for: addressData.dropFirst(varInt.bytesRead))
+        case .garlic64:
+            guard !addressData.isEmpty else { throw MultiaddrError.parseAddressFail }
+            let varInt = VarInt.uVarInt(addressData.bytes)
+            guard Int(varInt.value) + varInt.bytesRead == addressData.count else { throw MultiaddrError.parseAddressFail }
+            return try Garlic64.string(for: addressData.dropFirst(varInt.bytesRead))
         case .p2p, .ipfs:
-            return try IPFS.string(for: addressData)
-        case .dns4, .dns6, .dnsaddr, .unix:
+            return try P2P.string(for: addressData)
+        case .dns, .dns4, .dns6, .dnsaddr, .sni, .unix:
             return try DNS.string(for: addressData)
         case .http, .https, .utp, .udt, .ws, .wss, .quic, .p2p_circuit:
+            guard addressData.isEmpty else { throw MultiaddrError.parseAddressFail }
             return nil
+        //case .http, .https:
+        //    if addressData.isEmpty { return nil }
+        //    guard let str = String(data: addressData, encoding: .utf8) else { throw MultiaddrError.parseAddressFail }
+        //    return str
         case .certhash:
             guard !addressData.isEmpty else { throw MultiaddrError.parseAddressFail }
             let varInt = VarInt.uVarInt(addressData.bytes)
@@ -95,44 +130,75 @@ extension Address {
         }
     }
     
-    private func binaryPackedAddress() throws -> Data? {
-        guard let address = address else { return nil }
+    static private func binaryPackedAddress(_ address:String?, for addrProtocol:MultiaddrProtocol) throws -> Data? {
         switch addrProtocol {
         case .tcp, .udp, .dccp, .sctp:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             guard let port = UInt16(address) else { throw MultiaddrError.invalidPortValue }
             var bigEndianPort = port.bigEndian
             return Data(bytes: &bigEndianPort, count: MemoryLayout<UInt16>.size)
         case .ip4:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             return try IPv4.data(for: address)
         case .ip6:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             return try IPv6.data(for: address)
+        case .ip6zone:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
+            guard !address.contains("/") else { throw MultiaddrError.invalidFormat }
+            let data = Data(address.utf8)
+            return Data(putUVarInt(UInt64(data.count)) + data)
+        case .ipcidr:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
+            let ipMask = try Data(decoding: address, as: .base10)
+            guard ipMask.count == 1 else { throw MultiaddrError.parseAddressFail }
+            return ipMask
         case .onion:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             return try Onion.data(for: address)
         case .onion3:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             return try Onion3.data(for: address)
+        case .garlic32:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
+            return try Garlic32.data(for: address)
+        case .garlic64:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
+            return try Garlic64.data(for: address)
         case .p2p, .ipfs:
-            return try IPFS.data(for: address)
-        case .dns4, .dns6, .dnsaddr, .unix:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
+            return try P2P.data(for: address)
+        case .dns, .dns4, .dns6, .dnsaddr, .sni, .unix:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             return DNS.data(for: address)
         case .http, .https, .utp, .udt, .ws, .wss, .quic, .p2p_circuit:
+            guard address == nil else { throw MultiaddrError.parseAddressFail }
             return nil
+        //case .http, .https:
+        //    if let address = address {
+        //        return Data(address.utf8)
+        //    } else {
+        //        return nil
+        //    }
         case .certhash:
+            guard let address = address else { throw MultiaddrError.parseAddressFail }
             let mh = try Multihash(multihash: address)
             return Data(VarInt.putUVarInt(UInt64(mh.value.count)) + mh.value)
         default:
+            if address == nil { return nil }
             throw MultiaddrError.parseAddressFail
         }
     }
     
     static func byteSizeForAddress(_ proto: MultiaddrProtocol, buffer: [UInt8]) -> Int {
         switch proto.size() {
-        case .fixed(let bits):
-            return bits / 8
-        case .variable:
-            let (sizeValue, bytesRead) = VarInt.uVarInt(buffer) //Varint.readUVarInt(from: buffer)
-            return Int(sizeValue) + bytesRead
         case .zero:
             return 0
+        case .fixed(let bits):
+            return bits / 8
+        case .variableLengthPrefixed:
+            let (sizeValue, bytesRead) = VarInt.uVarInt(buffer) //Varint.readUVarInt(from: buffer)
+            return Int(sizeValue) + bytesRead
         }
     }
 }

--- a/Sources/Multiaddr/Extensions/Error+Multiaddr.swift
+++ b/Sources/Multiaddr/Extensions/Error+Multiaddr.swift
@@ -1,6 +1,6 @@
 //
 //  Error+Multiaddr.swift
-//  
+//
 //  Created by Luke Reichold
 //  Modified by Brandon Toms on 5/1/22.
 //
@@ -14,6 +14,7 @@ enum MultiaddrError: Error {
     case parseIPv6AddressFail
     case invalidPortValue
     case invalidOnionHostAddress
+    case invalidGarlicAddress
     case unknownProtocol
     case ipfsAddressLengthConflict
     case unknownCodec

--- a/Sources/Multiaddr/Protocol Helpers/Garlic.swift
+++ b/Sources/Multiaddr/Protocol Helpers/Garlic.swift
@@ -4,22 +4,20 @@
 //  Modified by Brandon Toms on 5/1/22.
 //
 
+import BaseX
 import Foundation
 import Multibase
 import VarInt
-import BaseX
 
 struct Garlic32 {
-    static let alphabet = "abcdefghijklmnopqrstuvwxyz234567"
-    
     static func data(for string: String) throws -> Data {
         if string.count < 55 && string.count != 52 { throw MultiaddrError.invalidGarlicAddress }
         let padded = string + String(repeating: "=", count: string.count % 8)
-        let decoded = try BaseEncoding.decode(padded, as: .base32Pad).data  // BaseX.decode(string, as: .custom(Garlic32.alphabet))
+        let decoded = try BaseEncoding.decode(padded, as: .base32Pad).data // BaseX.decode(string, as: .custom(Garlic32.alphabet))
         if decoded.count < 35 && decoded.count != 32 { throw MultiaddrError.invalidGarlicAddress }
         return Data(VarInt.putUVarInt(UInt64(decoded.count)) + decoded)
     }
-    
+
     static func string(for data: Data) throws -> String {
         if data.count < 35 && data.count != 32 { throw MultiaddrError.invalidGarlicAddress }
         var encoded = data.asString(base: .base32Pad) //BaseX.encode(data, into: .custom(Garlic32.alphabet))
@@ -31,14 +29,14 @@ struct Garlic32 {
 
 struct Garlic64 {
     static let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~"
-    
+
     static func data(for string: String) throws -> Data {
         guard string.count >= 516 && string.count <= 616 else { throw MultiaddrError.invalidGarlicAddress }
         let decoded = try BaseX.decode(string, as: .custom(Garlic64.alphabet))
         guard decoded.count >= 386 else { throw MultiaddrError.invalidGarlicAddress }
         return Data(VarInt.putUVarInt(UInt64(decoded.count)) + decoded)
     }
-    
+
     static func string(for data: Data) throws -> String {
         guard data.count >= 386 else { throw MultiaddrError.invalidGarlicAddress }
         let encoded = BaseX.encode(data, into: .custom(Garlic64.alphabet))

--- a/Sources/Multiaddr/Protocol Helpers/Garlic.swift
+++ b/Sources/Multiaddr/Protocol Helpers/Garlic.swift
@@ -1,0 +1,48 @@
+//
+//  Garlic.swift
+//
+//  Modified by Brandon Toms on 5/1/22.
+//
+
+import Foundation
+import Multibase
+import VarInt
+import BaseX
+
+struct Garlic32 {
+    static let alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+    
+    static func data(for string: String) throws -> Data {
+        if string.count < 55 && string.count != 52 { throw MultiaddrError.invalidGarlicAddress }
+        let padded = string + String(repeating: "=", count: string.count % 8)
+        let decoded = try BaseEncoding.decode(padded, as: .base32Pad).data  // BaseX.decode(string, as: .custom(Garlic32.alphabet))
+        if decoded.count < 35 && decoded.count != 32 { throw MultiaddrError.invalidGarlicAddress }
+        return Data(VarInt.putUVarInt(UInt64(decoded.count)) + decoded)
+    }
+    
+    static func string(for data: Data) throws -> String {
+        if data.count < 35 && data.count != 32 { throw MultiaddrError.invalidGarlicAddress }
+        var encoded = data.asString(base: .base32Pad) //BaseX.encode(data, into: .custom(Garlic32.alphabet))
+        while encoded.last == "=" { encoded.removeLast() }
+        if encoded.count < 55 && encoded.count != 52 { throw MultiaddrError.invalidGarlicAddress }
+        return encoded
+    }
+}
+
+struct Garlic64 {
+    static let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~"
+    
+    static func data(for string: String) throws -> Data {
+        guard string.count >= 516 && string.count <= 616 else { throw MultiaddrError.invalidGarlicAddress }
+        let decoded = try BaseX.decode(string, as: .custom(Garlic64.alphabet))
+        guard decoded.count >= 386 else { throw MultiaddrError.invalidGarlicAddress }
+        return Data(VarInt.putUVarInt(UInt64(decoded.count)) + decoded)
+    }
+    
+    static func string(for data: Data) throws -> String {
+        guard data.count >= 386 else { throw MultiaddrError.invalidGarlicAddress }
+        let encoded = BaseX.encode(data, into: .custom(Garlic64.alphabet))
+        guard encoded.count >= 516 && encoded.count <= 616 else { throw MultiaddrError.invalidGarlicAddress }
+        return encoded
+    }
+}

--- a/Sources/Multiaddr/Protocol Helpers/IPFS.swift
+++ b/Sources/Multiaddr/Protocol Helpers/IPFS.swift
@@ -5,17 +5,17 @@
 //  Modified by Brandon Toms on 5/1/22.
 //
 
+import CID
 import Foundation
 import Multihash
 import VarInt
-import CID
 
 struct P2P {
     static func data(for address: String) throws -> Data {
         let multihash = try (try? CID(address).multihash) ?? Multihash(multihash: address)
         return Data(putUVarInt(UInt64(multihash.value.count)) + multihash.value)
     }
-    
+
     static func string(for data: Data) throws -> String {
         let varInt = uVarInt(data.bytes)
         guard varInt.bytesRead + Int(varInt.value) == data.count else { throw MultiaddrError.invalidFormat }

--- a/Sources/Multiaddr/Protocol Helpers/IPFS.swift
+++ b/Sources/Multiaddr/Protocol Helpers/IPFS.swift
@@ -6,47 +6,19 @@
 //
 
 import Foundation
-import VarInt
-import Multibase
 import Multihash
+import VarInt
 import CID
 
-struct IPFS {
+struct P2P {
     static func data(for address: String) throws -> Data {
-//        let raw = try? BaseEncoding.decode(address, as: .base58btc)
-//        print(raw)
-//        let raw2 = try? BaseEncoding.decode(address) //36 bytes
-//        print(raw2)
-//        print("Checking if address is a valid multihash: \(address)")
-//        let mh = try Multihash(multihash: address)
-//        print(mh.b58String)
-//        return Data(mh.digest!)
-        
-        let addressBytes = Array(try BaseEncoding.decode(address, as: .base58btc).data) //Base58.bytesFromBase58(address)
-        let sizeBytes = UInt64(addressBytes.count).varIntData()
-        let combined = [Array(sizeBytes), addressBytes].flatMap { $0 }
-        return Data(bytes: combined, count: combined.count)
+        let multihash = try (try? CID(address).multihash) ?? Multihash(multihash: address)
+        return Data(putUVarInt(UInt64(multihash.value.count)) + multihash.value)
     }
     
     static func string(for data: Data) throws -> String {
-//        print("Checking if data is a valid multihash")
-//        return try Multihash(multihash: data).b58String
-        
-        let buffer = Array(data)
-        let decodedVarint = VarInt.uVarInt(buffer) //Varint.readUVarInt(from: buffer)
-        //let expectedSize = decodedVarint.value
-
-        let addressBytes = Array(buffer[decodedVarint.bytesRead...])
-        
-        // Commenting out this check due to using CID / Multihash Init as verification...
-        //guard addressBytes.count == expectedSize else { throw MultiaddrError.ipfsAddressLengthConflict }
-        
-        //Ensure addressBytes is a valid CID or Multihash compliant buffer and store it as a b58 String if so...
-        guard let str = (try? CID(addressBytes).multihash.b58String) ?? (try? Multihash(addressBytes).b58String) else {
-            throw MultiaddrError.ipfsAddressLengthConflict
-        }
-        return str
-        
-        //return addressBytes.asString(base: .base58btc) //Base58.base58FromBytes(addressBytes)
+        let varInt = uVarInt(data.bytes)
+        guard varInt.bytesRead + Int(varInt.value) == data.count else { throw MultiaddrError.invalidFormat }
+        return try Multihash(multihash: data.dropFirst(varInt.bytesRead)).b58String
     }
 }

--- a/Sources/Multiaddr/Protocol Helpers/Onion.swift
+++ b/Sources/Multiaddr/Protocol Helpers/Onion.swift
@@ -14,29 +14,30 @@ struct Onion {
         guard components.count == 2 else { throw MultiaddrError.invalidFormat }
 
         guard let host = components.first?.uppercased(),
-            host.count == 16,
-            let port =  components.last
+              host.count == 16,
+              let port = components.last
         else {
             throw MultiaddrError.invalidOnionHostAddress
         }
-        
+
         guard let portValue = UInt16(port) else { throw MultiaddrError.invalidPortValue }
+        guard portValue != 0 else { throw MultiaddrError.invalidPortValue }
 
         //base32DecodeToData(host)
         guard var onionData = try? BaseEncoding.decode(host, as: .base32).data else { throw MultiaddrError.invalidOnionHostAddress }
-        
+
         var bigEndianPort = portValue.bigEndian
         let portData = Data(bytes: &bigEndianPort, count: MemoryLayout<UInt16>.size)
-  
+
         onionData.append(portData)
         return onionData
     }
-    
+
     static func string(for data: Data) throws -> String {
         guard data.count == 12 else { throw MultiaddrError.invalidOnionHostAddress }
         let addressBytes = data.prefix(10)
         let portBytes = data.suffix(2)
-        
+
         let addressEncodedString = addressBytes.asString(base: .base32).lowercased() //base32Encode(addressBytes).lowercased()
         let portString = String(portBytes.uint16.bigEndian)
         return "\(addressEncodedString):\(portString)"
@@ -49,29 +50,30 @@ struct Onion3 {
         guard components.count == 2 else { throw MultiaddrError.invalidFormat }
 
         guard let host = components.first?.uppercased(),
-            host.count == 56,
-            let port =  components.last
+              host.count == 56,
+              let port = components.last
         else {
             throw MultiaddrError.invalidOnionHostAddress
         }
-        
+
         guard let portValue = UInt16(port) else { throw MultiaddrError.invalidPortValue }
+        guard portValue != 0 else { throw MultiaddrError.invalidPortValue }
 
         //base32DecodeToData(host)
         guard var onionData = try? BaseEncoding.decode(host, as: .base32).data else { throw MultiaddrError.invalidOnionHostAddress }
-        
+
         var bigEndianPort = portValue.bigEndian
         let portData = Data(bytes: &bigEndianPort, count: MemoryLayout<UInt16>.size)
-  
+
         onionData.append(portData)
         return onionData
     }
-    
+
     static func string(for data: Data) throws -> String {
         //guard data.count == 52 else { throw MultiaddrError.invalidOnionHostAddress }
-        let portBytes = data.suffix(2)
+        let portBytes = Data(data.suffix(2))
         let addressBytes = Data(data.dropLast(2))
-        
+
         let addressEncodedString = addressBytes.asString(base: .base32).lowercased() //base32Encode(addressBytes).lowercased()
         let portString = String(portBytes.uint16.bigEndian)
         return "\(addressEncodedString):\(portString)"

--- a/Sources/Multiaddr/Protocol.swift
+++ b/Sources/Multiaddr/Protocol.swift
@@ -12,46 +12,59 @@ public typealias MultiaddrProtocol = Codecs
 
 enum BitSize {
     case fixed(bits: Int)
-    case variable
+    case variableLengthPrefixed
     case zero
 }
 
 extension MultiaddrProtocol {
     func isMultiaddrProtocol() -> Bool {
         switch self {
-        case .ip4, .tcp, .dns, .dns4, .dns6, .dnsaddr, .udp, .dccp, .ip6, .ip6zone, .ipcidr, .quic, .quic_v1, .webtransport, .certhash, .sctp, .p2p_circuit, .udt, .utp, .unix, .p2p, .ipfs, .http, .https, .onion, .onion3, .garlic64, .garlic32, .p2p_webrtc_direct, .tls, .sni, .noise, .ws, .wss, .plaintextv2, .webrtc_direct, .webrtc:
-            return true
-        case .p2p_websocket_star, .p2p_webrtc_star: //, .p2pWebrtcDirect, .p2pCircuit, .memory:
-            return true
-        default:
-            return false
+            case .ip4, .tcp, .dns, .dns4, .dns6, .dnsaddr, .udp, .dccp, .ip6, .ip6zone, .ipcidr, .quic, .quic_v1, .webtransport, .certhash, .sctp, .p2p_circuit, .udt, .utp, .unix, .p2p, .ipfs, .http, .https, .onion, .onion3, .garlic64, .garlic32, .p2p_webrtc_direct, .tls, .sni, .noise, .ws, .wss, .plaintextv2, .webrtc_direct, .webrtc:
+                return true
+            case .p2p_websocket_star, .p2p_webrtc_star: //, .p2pWebrtcDirect, .p2pCircuit, .memory:
+                return true
+            default:
+                return false
         }
     }
-    
+
     /// The number of bits that an address of this protocol will consume.
     func size() -> BitSize {
         switch self {
-        case .ip4:
-            return .fixed(bits: 32)
-        case .tcp, .udp, .dccp, .sctp:
-            return .fixed(bits: 16)
-        case .ip6:
-            return .fixed(bits: 128)
-        case .onion:
-            return .fixed(bits: 96)
-        case .onion3:
-            return .fixed(bits: 296)
-        case .ipfs, .dns4, .dns6, .unix, .p2p:
-            return .variable
-        case .certhash:
-            return .variable
-        default:
-            return .zero
+            case .ip4:
+                return .fixed(bits: 32)
+            case .tcp, .udp, .dccp, .sctp:
+                return .fixed(bits: 16)
+            case .ip6:
+                return .fixed(bits: 128)
+            case .onion:
+                return .fixed(bits: 96)
+            case .onion3:
+                return .fixed(bits: 296)
+            case .ipcidr:
+                return .fixed(bits: 8)
+            case .ipfs, .dns, .dnsaddr, .dns4, .dns6, .unix, .p2p, .sni, .ip6zone:
+                return .variableLengthPrefixed
+            case .certhash:
+                return .variableLengthPrefixed
+            case .garlic32, .garlic64:
+                return .variableLengthPrefixed
+            default:
+                return .zero
         }
     }
-    
+
     func packedCode() -> Data {
         return code.varIntData()
+    }
+
+    func isEqual(_ codec: MultiaddrProtocol) -> Bool {
+        switch self {
+            case .ipfs, .p2p:
+                return codec == .p2p || codec == .ipfs
+            default:
+                return self == codec
+        }
     }
 }
 

--- a/Tests/MultiaddrTests/MultiaddrTests.swift
+++ b/Tests/MultiaddrTests/MultiaddrTests.swift
@@ -10,6 +10,24 @@ final class MultiaddrTests: XCTestCase {
         dump(addr)
     }
     
+    func testDoesntInstantiateFromEmptyData() {
+        XCTAssertThrowsError(try Multiaddr(Data())) { error in
+            XCTAssertEqual(error as! MultiaddrError, MultiaddrError.invalidFormat)
+        }
+    }
+    
+    func testDoesntInstantiateFromEmptyString() {
+        XCTAssertThrowsError(try Multiaddr("")) { error in
+            XCTAssertEqual(error as! MultiaddrError, MultiaddrError.invalidFormat)
+        }
+    }
+    
+    func testDoesntInstantiateFromSingleSlash() {
+        XCTAssertThrowsError(try Multiaddr("/")) { error in
+            XCTAssertEqual(error as! MultiaddrError, MultiaddrError.invalidFormat)
+        }
+    }
+    
     func testCreateMultiaddrFromString() throws {
         let m = try! Multiaddr("/ip4/127.0.0.1/udp/1234")
         let expectedAddress1 = try Address(addrProtocol: .ip4, address: "127.0.0.1")
@@ -49,7 +67,6 @@ final class MultiaddrTests: XCTestCase {
         XCTAssertThrowsError(try ma.mutatingSwap(address: "192.168.1.644", forCodec: .ip4))
         // Assert Valid Address works
         XCTAssertNoThrow(try ma.mutatingSwap(address: "192.168.1.44", forCodec: .ip4))
-        print(ma)
         
         // Assert Invalid UDP Port Throws Error
         XCTAssertThrowsError(try ma.mutatingSwap(address: "1235.1", forCodec: .udp))
@@ -57,7 +74,6 @@ final class MultiaddrTests: XCTestCase {
         // Assert Valid Port works
         XCTAssertNoThrow(try ma.mutatingSwap(address: "1235", forCodec: .udp))
         
-        print(ma)
         XCTAssertEqual(ma.description, "/ip4/192.168.1.44/udp/1235")
     }
     
@@ -109,62 +125,62 @@ final class MultiaddrTests: XCTestCase {
         XCTAssertEqual(addresses.count, 5)
     }
     
-    func testCreateMultiaddrFromBytes_IPv4() {
+    func testCreateMultiaddrFromBytes_IPv4() throws {
         let bytes = [0x04, 0xc0, 0x00, 0x02, 0x2a] as [UInt8] // 04c000022a
         let data = Data(bytes: bytes, count: bytes.count)
-        let m = try! Multiaddr(data)
+        let m = try Multiaddr(data)
        
         XCTAssertEqual("/ip4/192.0.2.42", m.description)
     }
     
-    func testCreateMultiaddrFromBytes_TcpAddress() {
+    func testCreateMultiaddrFromBytes_TcpAddress() throws {
         let bytes = [0x06, 0x10, 0xe1] as [UInt8]
         let data = Data(bytes: bytes, count: bytes.count)
         
-        let m_fromString = try! Multiaddr("/tcp/4321")
-        let m_fromData = try! Multiaddr(data)
+        let m_fromString = try Multiaddr("/tcp/4321")
+        let m_fromData = try Multiaddr(data)
         
         XCTAssertEqual(m_fromData.description, m_fromString.description)
-        XCTAssertEqual(try! m_fromData.binaryPacked(), try! m_fromString.binaryPacked())
+        XCTAssertEqual(try m_fromData.binaryPacked(), try m_fromString.binaryPacked())
      }
     
-    func testDnsSerialization() {
-        let addr = try! Multiaddr("/dns6/foo.com")
-        let serialized = try! addr.binaryPacked()
+    func testDnsSerialization() throws {
+        let addr = try Multiaddr("/dns6/foo.com")
+        let serialized = try addr.binaryPacked()
         
-        let deserialized = try! Multiaddr(serialized)
+        let deserialized = try Multiaddr(serialized)
         XCTAssertEqual(addr, deserialized)
     }
     
-    func testCreateMultiaddrFromBytes_Onion() {
+    func testCreateMultiaddrFromBytes_Onion() throws {
         
         let bytes = [0xBC, 0x03, 0x9a, 0x18, 0x08, 0x73, 0x06, 0x36, 0x90, 0x43, 0x09, 0x1f, 0x00, 0x50] as [UInt8]
         let data = Data(bytes: bytes, count: bytes.count)
         
-        let m_fromString = try! Multiaddr("/onion/timaq4ygg2iegci7:80")
-        let m_fromData = try! Multiaddr(data)
+        let m_fromString = try Multiaddr("/onion/timaq4ygg2iegci7:80")
+        let m_fromData = try Multiaddr(data)
         
         XCTAssertEqual(m_fromData.description, m_fromString.description)
-        XCTAssertEqual(try! m_fromData.binaryPacked(), try! m_fromString.binaryPacked())
+        XCTAssertEqual(try m_fromData.binaryPacked(), try m_fromString.binaryPacked())
     }
     
     /// IPFS Overload no longer exists (these should no longer be equal)
     /// - Note: https://github.com/multiformats/multicodec/pull/283
-    func testCreateMultiaddrFromBytes_IpfsAddress() {
+    func testCreateMultiaddrFromBytes_IpfsAddress() throws {
         let bytes = [0xa5, 0x03, 0x22, 0x12, 0x20, 0xd5, 0x2e, 0xbb, 0x89, 0xd8, 0x5b, 0x02, 0xa2, 0x84, 0x94, 0x82, 0x03, 0xa6, 0x2f, 0xf2, 0x83, 0x89, 0xc5, 0x7c, 0x9f, 0x42, 0xbe, 0xec, 0x4e, 0xc2, 0x0d, 0xb7, 0x6a, 0x68, 0x91, 0x1c, 0x0b] as [UInt8]
         let data = Data(bytes: bytes, count: bytes.count)
         
-        let m_fromData = try! Multiaddr(data)
-        let m_fromStringIPFS = try! Multiaddr("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
-        let m_fromStringP2P = try! Multiaddr("/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+        let m_fromData = try Multiaddr(data)
+        let m_fromStringIPFS = try Multiaddr("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+        let m_fromStringP2P = try Multiaddr("/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
         
-        /// The descriptions should not be same
+        /// The descriptions should not be the same
         XCTAssertNotEqual(m_fromData.description, m_fromStringIPFS.description)
         XCTAssertEqual(m_fromData.description, m_fromStringP2P.description)
         
         /// The binary data should be the same across p2p and deprecated ipfs codecs
-        XCTAssertEqual(try! m_fromData.binaryPacked(), try! m_fromStringP2P.binaryPacked())
-        XCTAssertNotEqual(try! m_fromData.binaryPacked(), try! m_fromStringIPFS.binaryPacked())
+        XCTAssertEqual(try m_fromData.binaryPacked(), try m_fromStringP2P.binaryPacked())
+        XCTAssertNotEqual(try m_fromData.binaryPacked(), try m_fromStringIPFS.binaryPacked())
     }
     
     func testCreateMultiaddrFromBytes_P2PAddressBase32() throws {
@@ -172,14 +188,19 @@ final class MultiaddrTests: XCTestCase {
         let data = Data(bytes: bytes, count: bytes.count)
         
         let addrBase32 = try Multiaddr("/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
-        let str = "/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t"
+        let base58Str = "/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t"
         let addrBase58 = try Multiaddr("/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
         
-        // Description should equal the base58 string
-        XCTAssertEqual(addrBase32.description, str)
+        // We preserve the encoding of the multihash when possible
+        XCTAssertEqual(addrBase32.description, "/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
+        // The two should be equal regardless of their string encodings
         XCTAssertEqual(addrBase32, addrBase58)
         XCTAssertEqual(addrBase32, try Multiaddr(data))
         XCTAssertEqual(addrBase58, try Multiaddr(data))
+        // We preserve the encoding of the multihash when possible
+        XCTAssertEqual(addrBase58.description, base58Str)
+        // When instantiated from bytes we default to base58 encoding
+        XCTAssertEqual(try Multiaddr(data).description, base58Str)
         XCTAssertEqual(try addrBase32.binaryPacked(), try addrBase58.binaryPacked())
     }
     
@@ -195,10 +216,10 @@ final class MultiaddrTests: XCTestCase {
     }
     
     func testCreateMultiaddrFromString_AddressValueHasMultipleSlashes() throws {
-        let m = try! Multiaddr("/dns4/foo.com/tcp/80/http/bar/baz.jpg")
+        let m = try Multiaddr("/dns4/foo.com/tcp/80/http/") // bar/baz.jpg
         let expectedAddress1 = try Address(addrProtocol: .dns4, address: "foo.com")
         let expectedAddress2 = try Address(addrProtocol: .tcp, address: "80")
-        let expectedAddress3 = try Address(addrProtocol: .http, address: "bar/baz.jpg")
+        let expectedAddress3 = try Address(addrProtocol: .http, address: nil) //"bar/baz.jpg")
         
         XCTAssertEqual(m.addresses[0], expectedAddress1)
         XCTAssertEqual(m.addresses[1], expectedAddress2)
@@ -206,7 +227,7 @@ final class MultiaddrTests: XCTestCase {
     }
     
     func testCreateMultiaddrFromString_AddressValueHasColons() throws {
-        let m = try! Multiaddr("/ip6/::1/tcp/3217")
+        let m = try Multiaddr("/ip6/::1/tcp/3217")
         let expectedAddress1 = try Address(addrProtocol: .ip6, address: "::1")
         let expectedAddress2 = try Address(addrProtocol: .tcp, address: "3217")
         
@@ -214,82 +235,80 @@ final class MultiaddrTests: XCTestCase {
         XCTAssertEqual(m.addresses[1], expectedAddress2)
     }
     
-    func testEncapsulated_BasedOnStringEquality() {
-        let m1 = try! Multiaddr("/ip4/127.0.0.1")
-        let m2 = try! Multiaddr("/udt")
+    func testEncapsulated_BasedOnStringEquality() throws {
+        let m1 = try Multiaddr("/ip4/127.0.0.1")
+        let m2 = try Multiaddr("/udt")
     
         let encapsulated = m1.encapsulate(m2)
         XCTAssertEqual(String(describing: encapsulated), "/ip4/127.0.0.1/udt")
         
-        let m3 = try! Multiaddr("/ip4/127.0.0.1")
-        let encapsulated2 = try! m3.encapsulate("/udp/1234")
+        let m3 = try Multiaddr("/ip4/127.0.0.1")
+        let encapsulated2 = try m3.encapsulate("/udp/1234")
         XCTAssertEqual(String(describing: encapsulated2), "/ip4/127.0.0.1/udp/1234")
     }
     
-    func testEncapsulated_BasedOnObjectEquality() {
-        let m1 = try! Multiaddr("/ip4/127.0.0.1")
-        let m2 = try! Multiaddr("/udt")
+    func testEncapsulated_BasedOnObjectEquality() throws {
+        let m1 = try Multiaddr("/ip4/127.0.0.1")
+        let m2 = try Multiaddr("/udt")
         
-        let expected = try! Multiaddr("/ip4/127.0.0.1/udt")
+        let expected = try Multiaddr("/ip4/127.0.0.1/udt")
         XCTAssertEqual(m1.encapsulate(m2), expected)
     }
     
-    func testDecapsulate() {
-        let full = try! Multiaddr("/ip4/1.2.3.4/tcp/80")
-        let m1 = try! Multiaddr("/tcp/80")
-        let m2 = try! Multiaddr("/ip4/1.2.3.4")
+    func testDecapsulate() throws {
+        let full = try Multiaddr("/ip4/1.2.3.4/tcp/80")
+        let m1 = try Multiaddr("/tcp/80")
+        let m2 = try Multiaddr("/ip4/1.2.3.4")
         
         XCTAssertEqual(full.decapsulate(m1), m2)
         
-        let m3 = try! Multiaddr("/dns4/foo.com/tcp/80/http/bar/baz.jpg")
+        let m3 = try Multiaddr("/dns4/foo.com/tcp/80/http/") //bar/baz.jpg")
         let decapsulated = m3.decapsulate(m1)
         XCTAssertEqual(decapsulated, try Multiaddr("/dns4/foo.com"))
     }
     
-    func testCreateMultiaddrFromString_FailsWithInvalidStrings() {
+    func testCreateMultiaddrFromString_FailsWithInvalidStrings() throws {
         let addresses = ["notAProtocol",
                    "/ip4/tcp/alsoNotAProtocol",
                    "////ip4/tcp/21432141///",
                    "////ip4///////tcp////"]
         
         for addr in addresses {
-            XCTAssertThrowsError(try Multiaddr(addr)) { error in
-                print("\(addr) was invalid")
-            }
+            XCTAssertThrowsError(try Multiaddr(addr), "Invalid string address `\(addr)` resulted in Multiaddr creation.")
         }
     }
 
-    func testBinaryPackedReturnsCorrectValue_For16BitProtocolPort() {
+    func testBinaryPackedReturnsCorrectValue_For16BitProtocolPort() throws {
         let expected = "0601bb"
-        let m = try! Multiaddr("/tcp/443")
-        let actual = try! m.binaryPacked().hexString()
+        let m = try Multiaddr("/tcp/443")
+        let actual = try m.binaryPacked().hexString()
         XCTAssertEqual(actual, expected)
     }
     
-    func testBinaryPackedReturnsCorrectValue_ForIPv4Address() {
+    func testBinaryPackedReturnsCorrectValue_ForIPv4Address() throws {
         let expected = "04c000022a"
-        let m = try! Multiaddr("/ip4/192.0.2.42")
-        let actual = try! m.binaryPacked().hexString()
+        let m = try Multiaddr("/ip4/192.0.2.42")
+        let actual = try m.binaryPacked().hexString()
         XCTAssertEqual(actual, expected)
     }
     
-    func testBinaryPackedThrowsError_ForInvalidIPv4Address() {
+    func testBinaryPackedThrowsError_ForInvalidIPv4Address() throws {
         XCTAssertThrowsError(try Multiaddr("/ip4/555.55.55.5").binaryPacked()) { error in
             XCTAssertEqual(error as! MultiaddrError, MultiaddrError.parseIPv4AddressFail)
         }
     }
     
-    func testBinaryPacked_ForOnionAddress_EncodesCorrectly() {
+    func testBinaryPacked_ForOnionAddress_EncodesCorrectly() throws {
         let expected = "bc039a18087306369043091f0050"
-        let m = try! Multiaddr("/onion/timaq4ygg2iegci7:80")
-        let actual = try! m.binaryPacked().hexString()
+        let m = try Multiaddr("/onion/timaq4ygg2iegci7:80")
+        let actual = try m.binaryPacked().hexString()
         XCTAssertEqual(actual, expected)
     }
     
-    func testBinaryPacked_ForP2PAddress_EncodesCorrectly() {
+    func testBinaryPacked_ForP2PAddress_EncodesCorrectly() throws {
         let expected = "a503221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a68911c0b"
-        let m = try! Multiaddr("/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
-        let actual = try! m.binaryPacked().hexString()
+        let m = try Multiaddr("/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+        let actual = try m.binaryPacked().hexString()
         XCTAssertEqual(actual, expected)
     }
     
@@ -326,7 +345,6 @@ final class MultiaddrTests: XCTestCase {
         let addy1Bytes = Data(hex: "046883835291020fa1cd03d103d203221220a78c594f830726e17fba30224d448d5c4a4434e9e5a14f24b3822d14da46d19bd203221220855beff35231e37b3c4970b3e16e0e100eba09adc3e1ad5473a16c97f258b61e")
         
         let ma = try Multiaddr(addy1Bytes)
-        print(ma)
         
         let addy1Packed = try ma.binaryPacked()
         XCTAssertEqual(addy1Bytes, addy1Packed)
@@ -360,9 +378,299 @@ final class MultiaddrTests: XCTestCase {
         XCTAssertThrowsError(try Multiaddr("/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp"))
     }
 
+    func testInvalidMutliaddr() throws {
+        let invalidAddresses = [
+            "/ip4",
+            "/ip4/::1",
+            "/ip4/fdpsofodsajfdoisa",
+            "/ip4/1.2.3.4/ipcidr/256",
+            "/ip6/::1/ipcidr/1026",
+            "/ip6",
+            "/ip6zone",
+            "/ip6zone/",
+            "/ip6zone//ip6/fe80::1",
+            "/udp",
+            "/tcp",
+            "/sctp",
+            "/udp/65536",
+            "/tcp/65536",
+            "/quic/65536",
+            "/quic-v1/65536",
+            "/onion/9imaq4ygg2iegci7:80",
+            "/onion/aaimaq4ygg2iegci7:80",
+            "/onion/timaq4ygg2iegci7:0",
+            "/onion/timaq4ygg2iegci7:-1",
+            "/onion/timaq4ygg2iegci7",
+            "/onion/timaq4ygg2iegci@:666",
+            "/onion3/9ww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:80",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd7:80",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:0",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:-1",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyy@:666",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA7:80",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:0",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:0",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:-1",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA@:666",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA7:80",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:0",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:0",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA:-1",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA@:666",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzu",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzu77",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzu:80",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq:-1",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzu@",
+            "/udp/1234/sctp",
+            "/udp/1234/udt/1234",
+            "/udp/1234/utp/1234",
+            "/ip4/127.0.0.1/udp/jfodsajfidosajfoidsa",
+            "/ip4/127.0.0.1/udp",
+            "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa",
+            "/ip4/127.0.0.1/tcp",
+            "/ip4/127.0.0.1/quic/1234",
+            "/ip4/127.0.0.1/quic-v1/1234",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
+            "/ip4/127.0.0.1/ipfs",
+            "/ip4/127.0.0.1/ipfs/tcp",
+            "/ip4/127.0.0.1/p2p",
+            "/ip4/127.0.0.1/p2p/tcp",
+            "/unix",
+            "/ip4/1.2.3.4/tcp/80/unix",
+            "/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",
+            "/",
+            ""
+        ]
+        
+        for address in invalidAddresses {
+            do {
+                let addy = try Multiaddr(address)
+                XCTFail("Address: \(address) -> \(addy)")
+            } catch {
+                continue
+            }
+        }
+    }
+    
+    func testValidMutliaddr() throws {
+        let validAddresses = [
+            "/ip4/1.2.3.4",
+            "/ip4/0.0.0.0",
+            "/ip4/192.0.2.0/ipcidr/24",
+            "/ip6/::1",
+            "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
+            "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21/udp/1234/quic",
+            "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21/udp/1234/quic-v1",
+            "/ip6/2001:db8::/ipcidr/32",
+            "/ip6zone/x/ip6/fe80::1",
+            "/ip6zone/x%y/ip6/fe80::1",
+            "/ip6zone/x%y/ip6/::",
+            "/ip6zone/x/ip6/fe80::1/udp/1234/quic",
+            "/ip6zone/x/ip6/fe80::1/udp/1234/quic-v1",
+            "/onion/timaq4ygg2iegci7:1234",
+            "/onion/timaq4ygg2iegci7:80/http",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:80/http",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA/http",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA/udp/8080",
+            "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA/tcp/8080",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuqzwas",
+            //"/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuqzwassw", // Base32Pad stray bits error
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq/http",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq/tcp/8080",
+            "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq/udp/8080",
+            "/udp/0",
+            "/tcp/0",
+            "/sctp/0",
+            "/udp/1234",
+            "/tcp/1234",
+            "/sctp/1234",
+            "/udp/65535",
+            "/tcp/65535",
+            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7",
+            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/p2p/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7",
+            "/p2p/bafzbeigvf25ytwc3akrijfecaotc74udrhcxzh2cx3we5qqnw5vgrei4bm",
+            "/p2p/12D3KooWCryG7Mon9orvQxcS1rYZjotPgpwoJNHHKcLLfE4Hf5mV",
+            "/p2p/k51qzi5uqu5dhb6l8spkdx7yxafegfkee5by8h7lmjh2ehc2sgg34z7c15vzqs",
+            "/p2p/bafzaajaiaejcalj543iwv2d7pkjt7ykvefrkfu7qjfi6sduakhso4lay6abn2d5u",
+            "/udp/1234/sctp/1234",
+            "/udp/1234/udt",
+            "/udp/1234/utp",
+            "/tcp/1234/http",
+            "/tcp/1234/tls/http",
+            "/tcp/1234/https",
+            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
+            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/p2p/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
+            "/ip4/127.0.0.1/udp/1234",
+            "/ip4/127.0.0.1/udp/0",
+            "/ip4/127.0.0.1/tcp/1234",
+            "/ip4/127.0.0.1/tcp/1234/",
+            "/ip4/127.0.0.1/udp/1234/quic",
+            "/ip4/127.0.0.1/udp/1234/quic-v1",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/b2uaraocy6yrdblb4sfptaddgimjmmpy",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/b2uaraocy6yrdblb4sfptaddgimjmmpy/certhash/zQmbWTwYGcmdyK9CYfNBcfs9nhZs17a6FQ4Y8oea278xx41",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ip4/127.0.0.1/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7",
+            "/ip4/127.0.0.1/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ip4/127.0.0.1/p2p/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7",
+            "/ip4/127.0.0.1/p2p/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
+            "/unix/a/b/c/d/e",
+            "/unix/stdio",
+            "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+            "/ip4/127.0.0.1/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234/unix/stdio",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+            "/ip4/127.0.0.1/p2p/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234/unix/stdio",
+            "/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
+            "/ip4/127.0.0.1/tcp/127/ws",
+            "/ip4/127.0.0.1/tcp/127/ws",
+            "/ip4/127.0.0.1/tcp/127/tls",
+            "/ip4/127.0.0.1/tcp/127/tls/ws",
+            "/ip4/127.0.0.1/tcp/127/noise",
+            "/ip4/127.0.0.1/tcp/127/wss",
+            "/ip4/127.0.0.1/tcp/127/wss",
+            "/ip4/127.0.0.1/tcp/127/webrtc-direct",
+            "/ip4/127.0.0.1/tcp/127/webrtc",
+        ]
+        
+        for address in validAddresses {
+            do {
+                let addy = try Multiaddr(address)
+                XCTAssertEqual(addy.description, address.hasSuffix("/") ? String(address.dropLast()) : address, "Failed to preserve string address: \(address)")
+                XCTAssertEqual(addy, try Multiaddr(addy.binaryPacked()), "Failed to roundtrip address: \(address)")
+            } catch {
+                XCTFail("Address: \(address) -> \(error)")
+            }
+        }
+    }
+    
+    func testEquality() throws {
+        let m1 = try Multiaddr("/ip4/127.0.0.1/udp/1234")
+        let m2 = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
+        let m3 = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
+        let m4 = try Multiaddr("/ip4/127.0.0.1/tcp/1234/")
+        
+        XCTAssertNotEqual(m1, m2)
+        XCTAssertNotEqual(m2, m1)
+        XCTAssertEqual(m1, m1)
+        XCTAssertEqual(m2, m3)
+        XCTAssertEqual(m3, m2)
+        XCTAssertEqual(m2, m4)
+        XCTAssertEqual(m3, m4)
+    }
+    
+    func testStringAddressToBinaryPacked() throws {
+        XCTAssertEqual(try Multiaddr("/ip4/127.0.0.1/udp/1234").binaryPacked().toHexString(), "047f000001910204d2")
+        XCTAssertEqual(try Multiaddr("/ip4/127.0.0.1/tcp/4321").binaryPacked().toHexString(), "047f0000010610e1")
+        XCTAssertEqual(try Multiaddr("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321").binaryPacked().toHexString(), "047f000001910204d2047f0000010610e1")
+        XCTAssertEqual(try Multiaddr("/onion/aaimaq4ygg2iegci:80").binaryPacked().toHexString(), "bc030010c0439831b48218480050")
+        XCTAssertEqual(try Multiaddr("/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234").binaryPacked().toHexString(), "bd03adadec040be047f9658668b11a504f3155001f231a37f54c4476c07fb4cc139ed7e30304d2")
+        XCTAssertEqual(try Multiaddr("/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA").binaryPacked().toHexString(), "be0383038d3fc8c976a86ae4e78ba378e75ec41bc9ab1542a9cb422581987e118f5cb0c024f3639d6ad9b3aff613672f07bfbbbfc2f920ef910534ecaa6ff9c03e0fa4872a764d2fce6d4cfc5a5a9800cd95944cc9ef0241f753fe71494a175f334b35682459acadc4076428ab49b5a83a49d2ea2366b06461e4a559b0111fa750e0de0c138a94d1231ed5979572ff53922905636221994bdabc44bd0c17fef11622b16432db3f193400af53cc61aa9bfc0c4c8d874b41a6e18732f0b60f5662ef1a89c80589dd8366c90bb58bb85ead56356aba2a244950ca170abbd01094539014f84bdd383e4a10e00cee63dfc3e809506e2d9b54edbdca1bace6eaa119e68573d30533791fba830f5d80be5c051a77c09415e3b8fe3139400848be5244b8ae96bb0c4a24f819cba0488f34985eac741d3359180bd72cafa1559e4c19f54ea8cedbb6a5afde4319396eb92aab340c60a50cc2284580cb3ad09017e8d9abc60269b3d8d687680bd86ce834412273d4f2e3bf68dd3d6fe87e2426ac658cd5c77fd5c0aa000000")
+        XCTAssertEqual(try Multiaddr("/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq").binaryPacked().toHexString(), "bf0320efbcd45d0c5dc79781ac6f20ea5055a036afb48d45a52e7d68ec7d4338919e69")
+    }
+    
+    func testBinaryPackedToStrings() throws {
+        XCTAssertEqual(try Multiaddr(Data(hex: "047f000001910204d2")).description, "/ip4/127.0.0.1/udp/1234")
+        XCTAssertEqual(try Multiaddr(Data(hex: "047f0000010610e1")).description, "/ip4/127.0.0.1/tcp/4321")
+        XCTAssertEqual(try Multiaddr(Data(hex: "047f000001910204d2047f0000010610e1")).description, "/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321")
+        XCTAssertEqual(try Multiaddr(Data(hex: "bc030010c0439831b48218480050")).description, "/onion/aaimaq4ygg2iegci:80")
+        XCTAssertEqual(try Multiaddr(Data(hex: "bd03adadec040be047f9658668b11a504f3155001f231a37f54c4476c07fb4cc139ed7e30304d2")).description, "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234")
+        XCTAssertEqual(try Multiaddr(Data(hex: "be0383038d3fc8c976a86ae4e78ba378e75ec41bc9ab1542a9cb422581987e118f5cb0c024f3639d6ad9b3aff613672f07bfbbbfc2f920ef910534ecaa6ff9c03e0fa4872a764d2fce6d4cfc5a5a9800cd95944cc9ef0241f753fe71494a175f334b35682459acadc4076428ab49b5a83a49d2ea2366b06461e4a559b0111fa750e0de0c138a94d1231ed5979572ff53922905636221994bdabc44bd0c17fef11622b16432db3f193400af53cc61aa9bfc0c4c8d874b41a6e18732f0b60f5662ef1a89c80589dd8366c90bb58bb85ead56356aba2a244950ca170abbd01094539014f84bdd383e4a10e00cee63dfc3e809506e2d9b54edbdca1bace6eaa119e68573d30533791fba830f5d80be5c051a77c09415e3b8fe3139400848be5244b8ae96bb0c4a24f819cba0488f34985eac741d3359180bd72cafa1559e4c19f54ea8cedbb6a5afde4319396eb92aab340c60a50cc2284580cb3ad09017e8d9abc60269b3d8d687680bd86ce834412273d4f2e3bf68dd3d6fe87e2426ac658cd5c77fd5c0aa000000")).description, "/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA")
+        XCTAssertEqual(try Multiaddr(Data(hex: "bf0320efbcd45d0c5dc79781ac6f20ea5055a036afb48d45a52e7d68ec7d4338919e69")).description, "/garlic32/566niximlxdzpanmn4qouucvua3k7neniwss47li5r6ugoertzuq")
+    }
+    
+    func testMultiaddrSplitDescription() throws {
+        XCTAssertEqual(
+            try Multiaddr("/ip4/1.2.3.4/udp/1234").addresses.map { $0.description },
+            [
+                "/ip4/1.2.3.4",
+                "/udp/1234"
+            ]
+        )
+        XCTAssertEqual(
+            try Multiaddr("/ip4/1.2.3.4/tcp/1/ip4/2.3.4.5/udp/2").addresses.map { $0.description },
+            [
+                "/ip4/1.2.3.4",
+                "/tcp/1",
+                "/ip4/2.3.4.5",
+                "/udp/2"
+            ]
+        )
+        XCTAssertEqual(
+            try Multiaddr("/ip4/1.2.3.4/utp/ip4/2.3.4.5/udp/2/udt").addresses.map { $0.description },
+            [
+                "/ip4/1.2.3.4",
+                "/utp",
+                "/ip4/2.3.4.5",
+                "/udp/2",
+                "/udt"
+            ]
+        )
+    }
+    
+    func testGetValueForProto() throws {
+        let ma = try Multiaddr("/ip4/127.0.0.1/utp/tcp/5555/udp/1234/tls/utp/ipfs/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .ip4)?.address, "127.0.0.1")
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .utp)?.address, nil)
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .tls)?.address, nil)
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .tcp)?.address, "5555")
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .udp)?.address, "1234")
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .ipfs)?.address, "QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
+        XCTAssertEqual(ma.getFirstAddress(forCodec: .p2p)?.address, "QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
+        
+        XCTAssertNil(ma.getFirstAddress(forCodec: .ip6))
+    }
+    
+    func testRoundTrip() throws {
+        let addresses = [
+            "/unix/a/b/c/d",
+            "/ip6/::ffff:127.0.0.1/tcp/111",
+            "/ip4/127.0.0.1/tcp/123",
+            "/ip4/127.0.0.1/tcp/123/tls",
+            "/ip4/127.0.0.1/udp/123",
+            "/ip4/127.0.0.1/udp/123/ip6/::",
+            "/ip4/127.0.0.1/udp/1234/quic-v1/webtransport/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
+            "/p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP",
+            "/p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP/unix/a/b/c",
+        ]
+        
+        for address in addresses {
+            let ma = try Multiaddr(address)
+            XCTAssertEqual(ma.description, address)
+            XCTAssertEqual(try Multiaddr(ma.binaryPacked()), ma)
+        }
+    }
+    
+    /// https://github.com/multiformats/multicodec/pull/283
+    func testIPFSvP2P() throws {
+        let p2pAddress = "/p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP"
+        let ipfsAddress = "/ipfs/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP"
+        
+        let p2p = try Multiaddr(p2pAddress)
+        let ipfs = try Multiaddr(ipfsAddress)
+        
+        XCTAssertEqual(p2p, ipfs)
+        XCTAssertNotEqual(ipfs.description, p2p.description)
+    }
+    
     static var allTests = [
         ("testDump", testDump),
-        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
+        ("testDoesntInstantiateFromEmptyData", testDoesntInstantiateFromEmptyData),
+        ("testDoesntInstantiateFromEmptyString", testDoesntInstantiateFromEmptyString),
+        ("testDoesntInstantiateFromSingleSlash", testDoesntInstantiateFromSingleSlash),
         ("testCreateMultiaddrFromString", testCreateMultiaddrFromString),
         ("testCreateMultiaddrFromString_LeadingSlashRequired", testCreateMultiaddrFromString_LeadingSlashRequired),
         ("testCreateMultiaddrFromString_WithoutAddressValue", testCreateMultiaddrFromString_WithoutAddressValue),
@@ -396,6 +704,16 @@ final class MultiaddrTests: XCTestCase {
         ("testDecodeEmbeddedCerthashFromBytes", testDecodeEmbeddedCerthashFromBytes),
         ("testConstructCerthashMultiaddr", testConstructCerthashMultiaddr),
         ("testFailesWithInvalidCerthash", testFailesWithInvalidCerthash),
+        ("testInvalidMutliaddr", testInvalidMutliaddr),
+        ("testValidMutliaddr", testValidMutliaddr),
+        ("testEquality", testEquality),
+        ("testStringAddressToBinaryPacked", testStringAddressToBinaryPacked),
+        ("testBinaryPackedToStrings", testBinaryPackedToStrings),
+        ("testMultiaddrSplitDescription", testMultiaddrSplitDescription),
+        ("testGetValueForProto", testGetValueForProto),
+        ("testRoundTrip", testRoundTrip),
+        ("testIPFSvP2P", testIPFSvP2P),
+        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
     ]
     
     /// Credit: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/

--- a/Tests/MultiaddrTests/ProtocolTests.swift
+++ b/Tests/MultiaddrTests/ProtocolTests.swift
@@ -5,42 +5,41 @@ import Multicodec
 
 class ProtocolsTests: XCTestCase {
 
-//    func testVarIntEncoding() {
-//        let proto1 = Protocol.ip6
-//        let expectedPackedValueAsHex1 = "29"
-//        let varIntEncodedBytes1 = proto1.packedCode().hexString()
-//        XCTAssertEqual(varIntEncodedBytes1, expectedPackedValueAsHex1)
-//
-//        let proto2 = Protocol.ip4
-//        let expectedPackedValueAsHex2 = "04"
-//        let varIntEncodedBytes2 = proto2.packedCode().hexString()
-//        XCTAssertEqual(varIntEncodedBytes2, expectedPackedValueAsHex2)
-//    }
+    func testVarIntEncoding() {
+        let proto1 = MultiaddrProtocol.ip6
+        let expectedPackedValueAsHex1 = "29"
+        let varIntEncodedBytes1 = proto1.packedCode().hexString()
+        XCTAssertEqual(varIntEncodedBytes1, expectedPackedValueAsHex1)
+
+        let proto2 = MultiaddrProtocol.ip4
+        let expectedPackedValueAsHex2 = "04"
+        let varIntEncodedBytes2 = proto2.packedCode().hexString()
+        XCTAssertEqual(varIntEncodedBytes2, expectedPackedValueAsHex2)
+    }
     
 //    it('create multiaddr', () => {
 //        udpAddr = multiaddr('/ip4/127.0.0.1/udp/1234')
 //        expect(udpAddr instanceof multiaddr).to.equal(true)
 //      })
     func testCreateMultiaddr() throws {
-        let udpAddr = try Multiaddr("/ip4/127.0.0.1/udp/1234")
-        print(udpAddr)
+        XCTAssertNoThrow(try Multiaddr("/ip4/127.0.0.1/udp/1234"))
     }
     
 //    it('clone multiaddr', () => {
 //        const udpAddrClone = multiaddr(udpAddr)
 //        expect(udpAddrClone !== udpAddr).to.equal(true)
 //      })
-    func testClone() {
-        var m1 = try! Multiaddr("/ip4/127.0.0.1")
+    func testClone() throws {
+        var m1 = try Multiaddr("/ip4/127.0.0.1")
         var cloned = m1
         XCTAssertEqual(m1, cloned)
         
-        let m2 = try! Multiaddr("/udp")
+        let m2 = try Multiaddr("/udp/1234")
         cloned = cloned.encapsulate(m2)
         XCTAssertNotEqual(m1, cloned)
         
         m1 = m1.encapsulate(m2)
-        let expected = try! Multiaddr("/ip4/127.0.0.1/udp")
+        let expected = try Multiaddr("/ip4/127.0.0.1/udp/1234")
         XCTAssertEqual(m1, expected)
         XCTAssertEqual(cloned, expected)
     }
@@ -716,7 +715,6 @@ class ProtocolsTests: XCTestCase {
     func testP2P_Multihash_Initialization() throws {
         let str = "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
         let addr = try Multiaddr(str)
-        print(addr)
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
@@ -732,9 +730,8 @@ class ProtocolsTests: XCTestCase {
     func testP2P_CID_Initialization() throws {
         let str = "/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4"
         let addr = try Multiaddr(str)
-        print(addr) //p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t
         // Description should equal initialization string
-        XCTAssertEqual(addr.description, "/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
+        XCTAssertEqual(addr.description, "/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
         XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")])
     }
     
@@ -752,7 +749,7 @@ class ProtocolsTests: XCTestCase {
         // Description should equal initialization string
         XCTAssertEqual(addr.description, str)
         XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .ipfs, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
-        XCTAssertNotEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
+        XCTAssertEqual(addr.addresses, [try Address(addrProtocol: .p2p, address: "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")])
     }
     
 //      it('onion', () => {
@@ -937,7 +934,7 @@ class ProtocolsTests: XCTestCase {
         let str = "/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4"
         let addr = try Multiaddr(str)
         // Description should equal initialization string
-        XCTAssertEqual(addr.description, "/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
+        XCTAssertEqual(addr.description, "/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
         XCTAssertEqual(addr.addresses, [
             try Address(addrProtocol: .ip4, address: "127.0.0.1"),
             try Address(addrProtocol: .tcp, address: "9090"),
@@ -1002,7 +999,6 @@ class ProtocolsTests: XCTestCase {
 //        ])
 //    }
     
-
     /// - MARK: PeerID Extraction Tests
     
     func testGetPeerID_P2P() throws {
@@ -1022,19 +1018,18 @@ class ProtocolsTests: XCTestCase {
 
     func testGetPeerID_P2P_CIDv1_BASE32() throws {
         let ma = try Multiaddr("/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4")
-        XCTAssertEqual(ma.getPeerID(), "QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi")
+        XCTAssertEqual(ma.getPeerID(), "bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4")
     }
 
     func testGetPeerID_P2P_CIDv1_BASE32_Nonb58_chars() throws {
         let ma = try Multiaddr("/p2p-circuit/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
-        XCTAssertEqual(ma.getPeerID(), "QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t")
+        XCTAssertEqual(ma.getPeerID(), "bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4")
     }
 
     func testGetPeerID_From_Address_Without_A_PeerID() throws {
         let ma = try Multiaddr("/ip4/0.0.0.0/tcp/1234/utp")
         XCTAssertNil(ma.getPeerID())
     }
-    
     
     /// - MARK: Path Extraction Tests
 //    it('should return a path for unix', () => {
@@ -1068,9 +1063,84 @@ class ProtocolsTests: XCTestCase {
     }
     
     static var allTests = [
-        //("testVarIntEncoding", testVarIntEncoding)
-        ("testCreateMultiaddr", testCreateMultiaddr)
+        ("testVarIntEncoding", testVarIntEncoding),
+        ("testCreateMultiaddr", testCreateMultiaddr),
+        ("testClone", testClone),
+        ("testCreateFromBuffer", testCreateFromBuffer),
+        ("testCreateFromString", testCreateFromString),
+        ("testCreateBasic", testCreateBasic),
+        ("testIPFSAddress", testIPFSAddress),
+        ("testIP4", testIP4),
+        ("testIP6", testIP6),
+        ("testIP4_TCP", testIP4_TCP),
+        ("testIP6_TCP", testIP6_TCP),
+        ("testIP4_UDP", testIP4_UDP),
+        ("testIP6_UDP", testIP6_UDP),
+        ("testIP4_P2P_TCP", testIP4_P2P_TCP),
+        ("testIP4_IPFS_TCP", testIP4_IPFS_TCP),
+        ("testIP6_P2P_TCP", testIP6_P2P_TCP),
+        ("testIP4_UDP_UTP", testIP4_UDP_UTP),
+        ("testIP6_UDP_UTP", testIP6_UDP_UTP),
+        ("testIP4_TCP_HTTP", testIP4_TCP_HTTP),
+        ("testIP4_TCP_UNIX", testIP4_TCP_UNIX),
+        ("testIP6_TCP_HTTP", testIP6_TCP_HTTP),
+        ("testIP6_TCP_UNIX", testIP6_TCP_UNIX),
+        ("testIP4_TCP_HTTPS", testIP4_TCP_HTTPS),
+        ("testIP6_TCP_HTTPS", testIP6_TCP_HTTPS),
+        ("testIP4_TCP_WS", testIP4_TCP_WS),
+        ("testIP6_TCP_WS", testIP6_TCP_WS),
+        ("testIP6_TCP_WS_IPFS", testIP6_TCP_WS_IPFS),
+        ("testIP6_TCP_WS_P2P", testIP6_TCP_WS_P2P),
+        ("testIP6_UDP_QUIC_IPFS", testIP6_UDP_QUIC_IPFS),
+        ("testIP6_UDP_QUIC_P2P", testIP6_UDP_QUIC_P2P),
+        ("testUNIX", testUNIX),
+        ("testP2P_Multihash_Initialization", testP2P_Multihash_Initialization),
+        ("testP2P_CID_Initialization", testP2P_CID_Initialization),
+        ("testIPFS", testIPFS),
+        ("testOnion", testOnion),
+        ("testOnion_BadLength", testOnion_BadLength),
+        ("testOnion_BadPort", testOnion_BadPort),
+        ("testOnion_NoPort", testOnion_NoPort),
+        ("testOnion3", testOnion3),
+        ("testOnion3_BadLength", testOnion3_BadLength),
+        ("testOnion3_BadPort", testOnion3_BadPort),
+        ("testOnion3_NoPort", testOnion3_NoPort),
+        ("testP2PCircuit", testP2PCircuit),
+        ("testP2P_P2PCircuit", testP2P_P2PCircuit),
+        ("testIPFS_P2PCircuit", testIPFS_P2PCircuit),
+        ("testIP4_TCP_WEBRTCSTAR_P2P", testIP4_TCP_WEBRTCSTAR_P2P),
+        ("testIP4_TCP_WEBRTCSTAR_IPFS", testIP4_TCP_WEBRTCSTAR_IPFS),
+        ("testIP4_TCP_WEBRTCSTAR_IPFS_CID", testIP4_TCP_WEBRTCSTAR_IPFS_CID),
+        ("testIP4_TCP_HTTP_WEBRTCDIRECT", testIP4_TCP_HTTP_WEBRTCDIRECT),
+        ("testIP4_TCP_WS_WEBSOCKETSTAR", testIP4_TCP_WS_WEBSOCKETSTAR),
+        ("testGetPeerID_P2P", testGetPeerID_P2P),
+        ("testGetPeerID_P2PCircuit", testGetPeerID_P2PCircuit),
+        ("testGetPeerID_IPFS", testGetPeerID_IPFS),
+        ("testGetPeerID_P2P_CIDv1_BASE32", testGetPeerID_P2P_CIDv1_BASE32),
+        ("testGetPeerID_P2P_CIDv1_BASE32_Nonb58_chars", testGetPeerID_P2P_CIDv1_BASE32_Nonb58_chars),
+        ("testGetPeerID_From_Address_Without_A_PeerID", testGetPeerID_From_Address_Without_A_PeerID),
+        ("testGetPathForUnix", testGetPathForUnix),
+        ("testGetPathForUnix_Multiple_Protos", testGetPathForUnix_Multiple_Protos),
+        ("testGetPathForUnix_No_Path", testGetPathForUnix_No_Path),
+        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
     ]
+    
+    /// Credit: https://oleb.net/blog/2017/03/keeping-xctest-in-sync/
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let thisClass = type(of: self)
+        let linuxCount = thisClass.allTests.count
+        #if swift(>=4.0)
+        let darwinCount = thisClass
+            .defaultTestSuite.testCaseCount
+        #else
+        let darwinCount = Int(thisClass
+            .defaultTestSuite().testCaseCount)
+        #endif
+        XCTAssertEqual(linuxCount, darwinCount,
+                       "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
+    }
 
 }
 


### PR DESCRIPTION
This PR... 
- Introduces support for
   - Garlic32, Garlic64
   - SNI
   - ipc6Zone
   - ipcidr
- Fixes encoding / decoding of a few other protocols. 
- Adds many new tests (most of which are inspired from [go-multiaddr](https://github.com/multiformats/go-multiaddr/blob/master/multiaddr_test.go))
- 🚨 Changes to equality checking and hashing (might be a breaking change in some applications).